### PR TITLE
chore: update .gitignore to exclude env and terraform files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 # terraform
 *.tfplan
 .terraform
+terraform.tfstate.*
+.terraform.tfstate.lock.info
+.tfvars
+
+# Other
+.env


### PR DESCRIPTION
# Summary

Update gitignore file to exclude `.env` file from being committed to git and also excluded Terraform files from being commented as recommended in Terraform docs (https://developer.hashicorp.com/terraform/language/style#gitignore)